### PR TITLE
rename CheckboxModelConfig to DynamicCheckboxModelConfig - Issue #78

### DIFF
--- a/modules/core/src/model/checkbox/dynamic-checkbox.model.ts
+++ b/modules/core/src/model/checkbox/dynamic-checkbox.model.ts
@@ -7,7 +7,7 @@ export const DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX = "CHECKBOX";
 export const DYNAMIC_FORM_CONTROL_CHECKBOX_ALIGN_START = "start";
 export const DYNAMIC_FORM_CONTROL_CHECKBOX_ALIGN_END = "end";
 
-export interface CheckboxModelConfig extends DynamicFormValueControlModelConfig {
+export interface DynamicCheckboxModelConfig extends DynamicFormValueControlModelConfig {
 
     align?: string;
     indeterminate?: boolean;
@@ -18,7 +18,7 @@ export class DynamicCheckboxModel extends DynamicFormValueControlModel<boolean> 
     align: string;
     indeterminate: boolean;
 
-    constructor(config: CheckboxModelConfig, cls?: ClsConfig) {
+    constructor(config: DynamicCheckboxModelConfig, cls?: ClsConfig) {
 
         super(config, cls);
 


### PR DESCRIPTION
Hello,

I tried to infer your CI routine from travis.yml
`npm run ci-tests` and all tests are passing.
`npm run ci-tsc`
`node_modules/@angular2-material/core/gestures/MdGestureConfig.d.ts(4,40): error TS2304: Cannot find name 'HammerManager'.
not ok`
`gulp build:modules` completes successfully.

I have not gotten e2e tests running on my machine. webdriver complaining about java.

Please point me to a contributions guide when you reject :).

Thanks,

