### PR TITLE
Client validation

### DIFF
--- a/example/app/foundation/foundation-example.component.html
+++ b/example/app/foundation/foundation-example.component.html
@@ -5,7 +5,8 @@
 
         <dynamic-form-foundation-sites-control *ngFor="let controlModel of dynamicFormModel"
                                                [controlGroup]="form"
-                                               [model]="controlModel">
+                                               [model]="controlModel"
+                                               [errorMessagesMap]="errorMessagesMap">
 
             <template *ngIf="controlModel.type === 'ARRAY'" let-index="index">
 

--- a/example/app/foundation/foundation-example.component.ts
+++ b/example/app/foundation/foundation-example.component.ts
@@ -28,6 +28,11 @@ export class FoundationExampleComponent implements OnInit {
     sampleArrayControl: FormArray;
     sampleArrayModel: DynamicFormArrayModel;
 
+    errorMessagesMap = {
+        required: "{{model.label}} is required",
+        pattern: "{{model.label}} doesn't match {{validator.requiredPattern}} pattern"
+    };
+
     constructor(private dynamicFormService: DynamicFormService) {
 
         this.dynamicFormModel = FOUNDATION_EXAMPLE_MODEL;

--- a/example/app/foundation/foundation-example.model.ts
+++ b/example/app/foundation/foundation-example.model.ts
@@ -7,6 +7,7 @@ import {
     DynamicTextAreaModel,
     DynamicFormArrayModel
 } from "@ng2-dynamic-forms/core";
+import {Validators} from "@angular/forms";
 
 export const FOUNDATION_EXAMPLE_MODEL = [
 
@@ -14,6 +15,7 @@ export const FOUNDATION_EXAMPLE_MODEL = [
         {
             id: "foundationSelect",
             label: "Example Select",
+            hint: "Option 4 is the only valid value",
             options: [
                 {
                     label: "Option 1",
@@ -33,7 +35,8 @@ export const FOUNDATION_EXAMPLE_MODEL = [
                     value: "option-4"
                 }
             ],
-            value: "option-3"
+            value: "option-3",
+            validators: [Validators.pattern("^option-4$")]
         },
         {
             element: {
@@ -88,11 +91,12 @@ export const FOUNDATION_EXAMPLE_MODEL = [
         {
             hint: "Just a sample help text",
             id: "foundationInput",
-            label: "Example Input",
+            label: "Example Input (Required)",
             maxLength: 51,
             placeholder: "example input",
             prefix: "Prefix",
-            suffix: "Suffix"
+            suffix: "Suffix",
+            validators: [Validators.required]
         },
         {
             element: {
@@ -140,9 +144,10 @@ export const FOUNDATION_EXAMPLE_MODEL = [
     new DynamicTextAreaModel(
         {
             id: "foundationTextArea",
-            label: "Example Textarea",
+            label: "Example Textarea (Required)",
             rows: 5,
             placeholder: "example Textarea",
+            validators: [Validators.required]
         },
         {
             element: {

--- a/example/app/foundation/foundation-example.model.ts
+++ b/example/app/foundation/foundation-example.model.ts
@@ -15,7 +15,6 @@ export const FOUNDATION_EXAMPLE_MODEL = [
         {
             id: "foundationSelect",
             label: "Example Select",
-            hint: "Option 4 is the only valid value",
             options: [
                 {
                     label: "Option 1",
@@ -35,13 +34,13 @@ export const FOUNDATION_EXAMPLE_MODEL = [
                     value: "option-4"
                 }
             ],
-            value: "option-3",
-            validators: [Validators.pattern("^option-4$")]
+            value: "option-3"
         },
         {
             element: {
                 container: "row",
-                label: "text-right middle font-bold"
+                label: "text-right middle font-bold",
+                error: "small-9 small-offset-3 columns"
             },
             grid: {
                 control: "small-9 columns",
@@ -91,7 +90,7 @@ export const FOUNDATION_EXAMPLE_MODEL = [
         {
             hint: "Just a sample help text",
             id: "foundationInput",
-            label: "Example Input (Required)",
+            label: "Example Input",
             maxLength: 51,
             placeholder: "example input",
             prefix: "Prefix",
@@ -101,7 +100,8 @@ export const FOUNDATION_EXAMPLE_MODEL = [
         {
             element: {
                 container: "row",
-                label: "text-right middle font-bold"
+                label: "text-right middle font-bold",
+                error: "small-9 small-offset-3 columns"
             },
             grid: {
                 control: "small-9 columns",
@@ -144,15 +144,16 @@ export const FOUNDATION_EXAMPLE_MODEL = [
     new DynamicTextAreaModel(
         {
             id: "foundationTextArea",
-            label: "Example Textarea (Required)",
+            label: "Example Textarea",
             rows: 5,
             placeholder: "example Textarea",
-            validators: [Validators.required]
+            validators: [Validators.required, Validators.pattern("[a-c]+")]
         },
         {
             element: {
                 container: "row",
-                label: "text-right font-bold"
+                label: "text-right font-bold",
+                error: "small-9 small-offset-3 columns"
             },
             grid: {
                 control: "small-9 columns",

--- a/modules/core/src/model/dynamic-form-control.model.ts
+++ b/modules/core/src/model/dynamic-form-control.model.ts
@@ -8,6 +8,7 @@ export interface Cls {
     container?: string;
     control?: string;
     label?: string;
+    error?: string;
 }
 
 export interface ClsConfig {

--- a/modules/ui-foundation/src/dynamic-form-foundation-sites.component.html
+++ b/modules/ui-foundation/src/dynamic-form-foundation-sites.component.html
@@ -6,7 +6,7 @@
          [ngClass]="model.cls.grid.label">
 
         <label [attr.for]="model.id"
-               [ngClass]="model.cls.element.label" [class.is-invalid-label]="showErrors">{{model.label}}</label>
+               [ngClass]="model.cls.element.label" [class.is-invalid-label]="isShowErrors">{{model.label}}</label>
     </div>
 
 
@@ -121,7 +121,7 @@
                    [required]="model.required"
                    [spellcheck]="model.spellCheck"
                    [type]="model.inputType"
-                   [class.is-invalid-input]="showErrors"
+                   [class.is-invalid-input]="isShowErrors"
                    (blur)="onBlur($event)"
                    (change)="onChange($event)"
                    (focus)="onFocus($event)"/>
@@ -164,7 +164,7 @@
                 [name]="model.name"
                 [ngClass]="model.cls.element.control"
                 [required]="model.required"
-                [class.is-invalid-input]="showErrors"
+                [class.is-invalid-input]="isShowErrors"
                 (blur)="onBlur($event)"
                 (change)="onChange($event)"
                 (focus)="onFocus($event)">
@@ -192,7 +192,7 @@
                   [rows]="model.rows"
                   [spellcheck]="model.spellCheck"
                   [wrap]="model.wrap"
-                  [class.is-invalid-input]="showErrors"
+                  [class.is-invalid-input]="isShowErrors"
                   (blur)="onBlur($event)"
                   (change)="onChange($event)"
                   (focus)="onFocus($event)"></textarea>

--- a/modules/ui-foundation/src/dynamic-form-foundation-sites.component.html
+++ b/modules/ui-foundation/src/dynamic-form-foundation-sites.component.html
@@ -201,6 +201,10 @@
 
     </div>
 
+    <div [ngClass]="model.cls.element.error">
+        <span *ngFor="let error of errorMessages" class="form-error" [class.is-visible]="isShowErrors">{{error}}</span>
+    </div>
+
     <ng-content></ng-content>
 
 </div>

--- a/modules/ui-foundation/src/dynamic-form-foundation-sites.component.html
+++ b/modules/ui-foundation/src/dynamic-form-foundation-sites.component.html
@@ -6,7 +6,7 @@
          [ngClass]="model.cls.grid.label">
 
         <label [attr.for]="model.id"
-               [ngClass]="model.cls.element.label">{{model.label}}</label>
+               [ngClass]="model.cls.element.label" [class.is-invalid-label]="showErrors">{{model.label}}</label>
     </div>
 
 
@@ -121,6 +121,7 @@
                    [required]="model.required"
                    [spellcheck]="model.spellCheck"
                    [type]="model.inputType"
+                   [class.is-invalid-input]="showErrors"
                    (blur)="onBlur($event)"
                    (change)="onChange($event)"
                    (focus)="onFocus($event)"/>
@@ -163,6 +164,7 @@
                 [name]="model.name"
                 [ngClass]="model.cls.element.control"
                 [required]="model.required"
+                [class.is-invalid-input]="showErrors"
                 (blur)="onBlur($event)"
                 (change)="onChange($event)"
                 (focus)="onFocus($event)">
@@ -190,6 +192,7 @@
                   [rows]="model.rows"
                   [spellcheck]="model.spellCheck"
                   [wrap]="model.wrap"
+                  [class.is-invalid-input]="showErrors"
                   (blur)="onBlur($event)"
                   (change)="onChange($event)"
                   (focus)="onFocus($event)"></textarea>

--- a/modules/ui-foundation/src/dynamic-form-foundation-sites.component.ts
+++ b/modules/ui-foundation/src/dynamic-form-foundation-sites.component.ts
@@ -28,4 +28,8 @@ export class DynamicFormFoundationSitesComponent extends DynamicFormControlCompo
     constructor() {
         super();
     }
+
+    public get showErrors(): boolean {
+        return this.control.touched && this.control.invalid;
+    }
 }

--- a/modules/ui-foundation/src/dynamic-form-foundation-sites.component.ts
+++ b/modules/ui-foundation/src/dynamic-form-foundation-sites.component.ts
@@ -29,7 +29,7 @@ export class DynamicFormFoundationSitesComponent extends DynamicFormControlCompo
         super();
     }
 
-    public get showErrors(): boolean {
+    public get isShowErrors(): boolean {
         return this.control.touched && this.control.invalid;
     }
 }

--- a/modules/ui-foundation/src/dynamic-form-foundation-sites.component.ts
+++ b/modules/ui-foundation/src/dynamic-form-foundation-sites.component.ts
@@ -17,6 +17,7 @@ export class DynamicFormFoundationSitesComponent extends DynamicFormControlCompo
     @Input() controlGroup: FormGroup;
     @Input() model: DynamicFormControlModel;
     @Input() nestedTemplate: TemplateRef<any>;
+    @Input() errorMessagesMap: {[key: string]: string} = {};
 
     @Output() blur: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
     @Output() focus: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
@@ -31,5 +32,35 @@ export class DynamicFormFoundationSitesComponent extends DynamicFormControlCompo
 
     public get isShowErrors(): boolean {
         return this.control.touched && this.control.invalid;
+    }
+
+    public get errorMessages(): string[] {
+        let errorMessages = [];
+        let errors = this.control.errors;
+
+        for(let validatorName in errors) {
+            let message: string;
+            let validationObj = errors[validatorName];
+
+            if(this.errorMessagesMap[validatorName]) {
+                message = this.errorMessagesMap[validatorName].replace(/\{\{(model|validator)\.(.+?)\}\}/mg, (match, variableSource, variableName) => {
+                    let replacement;
+
+                    if(variableSource === "model" && this.model[variableName]) {
+                        replacement = <string> this.model[variableName];
+                    } else if(variableSource === "validator" && typeof validationObj === "object" && validationObj[variableName]) {
+                        replacement = <string> validationObj[variableName];
+                    }
+
+                    return replacement;
+                });
+            } else {
+                message = `Validation "${validatorName}" failed`;
+            }
+
+            errorMessages.push(message);
+        }
+
+        return errorMessages;
     }
 }


### PR DESCRIPTION
The main idea behind these changes is to add convinience way to enable client validation using native "foundation" css classes.  I think it is very useful to have such abilities in terms of useability.
This is an example how it may look:
![2016-10-15_2053](https://cloud.githubusercontent.com/assets/6803001/19411524/3cb079b2-9325-11e6-8567-eae32247c930.png)

It can be applied to other UIs with small changes, basic concept is applicable for all UIs, I believe.
In order to merge this PR, I think we need to do 2 additional things:
1. Cover this feature by unit tests.
2. Add description to documentation.

Any thoughts?