### PR TITLE
Added ability to use validator's properties in error message templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,9 @@ new DynamicInputModel({
         }
 })
 ```
+Error message template allows the following placeholders: 
+- ```{{property_name}}``` where property_name is property of model, for example ```{{label}}```.
+- ```{{validator.property_name}}``` where property_name is property of object returned by validation function, for example ```{{validator.requiredPattern}}``` in case of pattern validator.
 
 **2. Enable error messaging by binding the** `@Input() hasErrorMessaging` **property of any** `DynamicFormBootstrapComponent` **or** 
 `DynamicFormFoundationSitesComponent` **to** `true`:

--- a/example/app/foundation/foundation-example.model.ts
+++ b/example/app/foundation/foundation-example.model.ts
@@ -179,7 +179,7 @@ export const FOUNDATION_EXAMPLE_MODEL = [
             },
             errorMessages: {
                 required: "{{label}} is required",
-                pattern: "{{label}} does not match pattern [a-c]"
+                pattern: "{{label}} does not match pattern {{validator.requiredPattern}}"
             }
         },
         {

--- a/modules/core/src/component/dynamic-form-control.component.ts
+++ b/modules/core/src/component/dynamic-form-control.component.ts
@@ -97,8 +97,16 @@ export abstract class DynamicFormControlComponent implements OnInit, AfterConten
 
                 if (this.model["errorMessages"][validatorName]) {
 
-                    message = this.model["errorMessages"][validatorName].replace(/\{\{(.+?)\}\}/mg,
-                        (match, propertyName) => this.model[propertyName] ? this.model[propertyName] : null);
+                    message = this.model["errorMessages"][validatorName].replace(/\{\{(.+?)\}\}/mg, (match, propertyName) => {
+                        let propertySource = this.model;
+
+                        if (propertyName.indexOf("validator.") >= 0) {
+                            propertySource = this.control.errors[validatorName];
+                            propertyName = propertyName.replace("validator.", "");
+                        }
+
+                        return propertySource[propertyName] ? propertySource[propertyName] : null;
+                    });
 
                 } else {
                     message = `Error on "${validatorName}" validation`;


### PR DESCRIPTION
These changes allow to define more flexible error message, where placoholders can be replace not only with model properties, but also with properties of object returned by validator. For example, when I define I create parameterized "MaxLength" validator, I'd like to be able to use defined max length in error message.