### PR TITLE
#356 Replace fieldset by a div to avoid vertical button group

### DIFF
--- a/modules/ui-ng-bootstrap/src/dynamic-form-ng-bootstrap.component.html
+++ b/modules/ui-ng-bootstrap/src/dynamic-form-ng-bootstrap.component.html
@@ -140,7 +140,7 @@
             </div>
 
 
-            <fieldset *ngSwitchCase="7" ngbRadioGroup role="radiogroup"
+            <div *ngSwitchCase="7" ngbRadioGroup role="radiogroup"
                       [attr.tabindex]="model.tabIndex"
                       [dynamicId]="bindId && model.id"
                       [formControlName]="model.id"
@@ -160,7 +160,7 @@
                            (focus)="onFocusChange($event)"/><span [innerHTML]="option.label"></span>
                 </label>
 
-            </fieldset>
+            </div>
 
 
             <select *ngSwitchCase="8" class="form-control"


### PR DESCRIPTION
I don't think a fieldset is needed here. The button group can be considered as only one control.